### PR TITLE
Правки #3 после первой проверки проекта

### DIFF
--- a/src/pages/offer-page/offer-page.tsx
+++ b/src/pages/offer-page/offer-page.tsx
@@ -183,10 +183,10 @@ export default function OfferPage() {
                   {capitalizeFirstLetter(currentOffer.type)}
                 </li>
                 <li className="offer__feature offer__feature--bedrooms">
-                  {currentOffer.bedrooms} Bedrooms
+                  {currentOffer.bedrooms} {currentOffer.bedrooms > 1 ? 'Bedrooms' : 'Bedroom'}
                 </li>
                 <li className="offer__feature offer__feature--adults">
-                  Max {currentOffer.maxAdults} adults
+                  Max {currentOffer.maxAdults} {currentOffer.maxAdults > 1 ? 'adults' : 'adult'}
                 </li>
               </ul>
               <div className="offer__price">


### PR DESCRIPTION
Супер маленькая правка: теперь правильно отображается множественное или единственное число в информации о числе проживающих. 1 Bedroom / 2 Bedrooms, Max 2 adults / Max 1 adult